### PR TITLE
fix: protect /dashboard routes via Clerk middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,1 @@
+export { default, config } from './proxy'


### PR DESCRIPTION
Fixes #4

## Root cause

`src/proxy.ts` contained the correct Clerk middleware (`clerkMiddleware` + `createRouteMatcher(["/dashboard(.*)"])`) but Next.js only recognises `middleware.ts` as its middleware entry point. `proxy.ts` was never executed, so unauthenticated requests bypassed the auth gate and reached the dashboard page, causing `getCurrentUserId()` to throw `Unauthorized`.

## Fix

Added `src/middleware.ts` that re-exports from `proxy.ts`, so Next.js wires up the Clerk middleware while the protection logic stays in `proxy.ts`.

Generated with [Claude Code](https://claude.ai/code)