### PR TITLE
feat: replace plain button elements with shadcn/ui Button in layout h…

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { ClerkProvider, SignInButton, SignUpButton, Show, UserButton } from "@cl
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Button } from "@/components/ui/button";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -33,14 +34,10 @@ export default function RootLayout({
           <header className="flex items-center justify-end gap-3 px-6 py-4">
             <Show when="signed-out">
               <SignInButton mode="modal">
-                <button className="rounded-full border border-black/[.08] px-4 py-2 text-sm font-medium transition-colors hover:border-transparent hover:bg-black/[.04] dark:border-white/[.145] dark:hover:bg-[#1a1a1a]">
-                  Sign in
-                </button>
+                <Button variant="outline">Sign in</Button>
               </SignInButton>
               <SignUpButton mode="modal">
-                <button className="rounded-full bg-foreground px-4 py-2 text-sm font-medium text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]">
-                  Sign up
-                </button>
+                <Button>Sign up</Button>
               </SignUpButton>
             </Show>
             <Show when="signed-in">


### PR DESCRIPTION
…eader

Replaces the hand-rolled Tailwind CSS <button> tags for Sign In and Sign Up in the site header with the shadcn/ui Button component, consistent with how buttons are already used in page.tsx.